### PR TITLE
Add detecting of column names for R code

### DIFF
--- a/R/jagsModule.R
+++ b/R/jagsModule.R
@@ -792,7 +792,7 @@ JAGS <- function(jaspResults, dataset, options, state = NULL) {
       if (is.null(string) || string == "" || string == "...") { # this shouldn't be possible, but if string = NULL, parse prompts for user input.
         next
       }
-      obj <- try(eval(parse(text = encodeColNames(string)), envir = envir, enclos = globalenv()))
+      obj <- try(eval(parse(text = string), envir = envir, enclos = globalenv()))
       if (isTryError(obj)) {
         jaspResults[["mainContainer"]]$setError(gettextf("The R code for %1$s crashed with error:\n%2$s",
                                                          type, .extractErrorMessage(obj)))

--- a/R/jagsModule.R
+++ b/R/jagsModule.R
@@ -832,7 +832,7 @@ JAGS <- function(jaspResults, dataset, options, state = NULL) {
       options$initialValues[[2L]]$values
     )
   )
-  allColumnNames <- names(.readDataSetHeader(all.columns = TRUE))
+  allColumnNames <- .allColumnNamesDataset()
   columnsFound <- c()
   if (length(allColumnNames) > 0L)
     for (target in targets) {


### PR DESCRIPTION
Currently, if you use column names of the data set in the R code for either initial values or observed values, then QML evaluates this code in an environment where the data set is attached. That works fine. However, the R side does not do that (it only attached the variables used in the JAGS model code) and you get an error. This PR fixes that problem.

a model to test this:

```r
model {
  theta ~ dbeta(1, 1)
}
```

and then enter under `Observed Values` (as R code):
```r
cbind(contNormal, contGamma)
```
with some other name than `theta`.

That crashes on master but not on this pr.

the function `.JAGSlocateColumnNamesInExpression` may look a bit funky. It's inspired by this [SE answer](https://stackoverflow.com/a/33850689/4917834). Basically, it loops over the structure of the expression so that it makes a distinction between function calls and arguments to those functions (and only the latter can be column names). Ideally, this means that a column name like `rnorm` would work in a call like `rnorm(length(rnorm))` but due to an issue with `encodeColNames` that doesn't work (yet).
