### PR TITLE
add .onAttach function to guide rjags to the jags installation

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,0 +1,16 @@
+.onAttach <- function(libname, pkgname) {
+
+  # function from zzzWrappers.R inside jaspResults
+  jaspResultsCalledFromJasp <- mget("jaspResultsCalledFromJasp", envir = .GlobalEnv, mode = "function", ifnotfound = NA)
+
+  if (!is.na(jaspResultsCalledFromJasp) &&
+      jaspBase:::getOS() == "osx" &&
+      isTRUE(try(jaspResultsCalledFromJasp()))
+  ) {
+
+    jagsHome <- Sys.getenv("JAGS_HOME")
+    options(jags.moddir = file.path(jagsHome, "modules-4"))
+    runjags::runjags.options(jagspath = jagsHome)
+
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-test-release/issues/1264, https://github.com/jasp-stats/INTERNAL-jasp/issues/1345

or so I hope, I could not test this on macOS.