### PR TITLE
Encode column names in user R code

### DIFF
--- a/R/jagsModule.R
+++ b/R/jagsModule.R
@@ -789,7 +789,7 @@ JAGS <- function(jaspResults, dataset, options, state = NULL) {
 
   type <- match.arg(type)
   paramNms <- unlist(input[[1L]][["values"]])
-  rcodes   <- unlist(input[[2L]][["values"]])
+  rcodes   <- encodeColNames(unlist(input[[2L]][["values"]]))
 
   output <- vector("list", length = noChains)
   for (j in seq_len(noChains)) {


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-issues/issues/1512

QML sends this to R:
```
"userData" : [
      {
         "levels" : [ "Row 0", "Row 1" ],
         "name" : "Parameter",
         "values" : [ "nPeople", "nTotalTrials" ]
      },
      {
         "levels" : [ "Row 0", "Row 1" ],
         "name" : "R Code",
         "values" : [ "nPeople <- length(unique(person))", "nTotalTrials <- length(person)" ]
      }
   ]
```
However, R mistakenly assumed that column names would be encoded. To fix this we ask the column encoder to always encode column names found the strings.