### PR TITLE
Set maximum for thinning and fix JAGSmodelError

### DIFF
--- a/R/jagsModule.R
+++ b/R/jagsModule.R
@@ -178,7 +178,7 @@ JAGS <- function(jaspResults, dataset, options, state = NULL) {
 
   # if something went wrong, present useful error message
   if (isTryError(e)) {
-    jaspResults[["mainContainer"]]$setError(.JAGSmodelError(e, model, options))
+    jaspResults[["mainContainer"]]$setError(.JAGSmodelError(e, options))
     return(NULL)
   }
 
@@ -724,11 +724,12 @@ JAGS <- function(jaspResults, dataset, options, state = NULL) {
   return(trimws(paste(split[-1L], collapse = "\n")))
 }
 
-.JAGSmodelError <- function(error, model, options) {
+.JAGSmodelError <- function(error, options) {
 
   errorMessage <- .extractJAGSErrorMessage(error)
 
-  # perhaps some helpfull checks...
+  # perhaps some helpful checks...
+  modelString <- options[["model"]][["model"]]
   chars <- stringr::fixed(c("[", "]", "{", "}", "(", ")"))
   counts <- stringr::str_count(model, chars)
   toAdd <- paste(

--- a/inst/qml/JAGS.qml
+++ b/inst/qml/JAGS.qml
@@ -152,6 +152,7 @@ Form
 			title: qsTr("MCMC parameters")
 			IntegerField
 			{
+				id: noSamples
 				name: "noSamples"
 				label: qsTr("No. samples")
 				defaultValue: 2e3
@@ -174,7 +175,7 @@ Form
 				label: qsTr("Thinning")
 				defaultValue: 1
 				min: 1
-				max: 1e9
+				max: Math.floor(noSamples.value / 2)
 				fieldWidth: 100
 			}
 			IntegerField


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-test-release/issues/1712

This PR fixes two things.

1. Thinning can be at most `floor(noSamples / 2)`.
2. `.JAGSmodelError` was sometimes passed a jags model object instead of a string with the jags model (depending on when the try errored). That's why the error in the screenshot of the linked issue mentions "The model contains more "}" than "{", even though this is not true.