### PR TITLE
Use correct variable name when throwing an error

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -12,7 +12,7 @@ jobs:
 
   unit-tests:
 
-    uses: jasp-stats/jasp-actions/.github/workflows/unittests.yml@fix_jags_installation_macOS
+    uses: jasp-stats/jasp-actions/.github/workflows/unittests.yml@master
     with:
       needs_JAGS:   true
       needs_igraph: false

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -12,7 +12,7 @@ jobs:
 
   unit-tests:
 
-    uses: jasp-stats/jasp-actions/.github/workflows/unittests.yml@master
+    uses: jasp-stats/jasp-actions/.github/workflows/unittests.yml@fix_jags_installation_macOS
     with:
       needs_JAGS:   true
       needs_igraph: false

--- a/R/jagsModule.R
+++ b/R/jagsModule.R
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013-2019 University of Amsterdam
+# Copyright (C) 2013-2022 University of Amsterdam
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -731,7 +731,7 @@ JAGS <- function(jaspResults, dataset, options, state = NULL) {
   # perhaps some helpful checks...
   modelString <- options[["model"]][["model"]]
   chars <- stringr::fixed(c("[", "]", "{", "}", "(", ")"))
-  counts <- stringr::str_count(model, chars)
+  counts <- stringr::str_count(modelString, chars)
   toAdd <- paste(
     .JAGSmodelErrorString(counts[1:2], chars[1:2]),
     .JAGSmodelErrorString(counts[3:4], chars[3:4]),


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/1816
Fixes https://github.com/jasp-stats/jasp-issues/issues/1691

for the first issue you now get this expected error:
![image](https://user-images.githubusercontent.com/21319932/164493590-1104e6b6-cc46-4413-97a9-80b70e2e8af9.png)

for the second issue you get this expected error:
![image](https://user-images.githubusercontent.com/21319932/164493876-2d9063c8-0e26-434e-a0d4-22ec5a46f5d8.png)
