### PR TITLE
JAGS cannot be loaded anymore on mac

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -3,8 +3,7 @@
   # function from zzzWrappers.R inside jaspResults
   jaspResultsCalledFromJasp <- mget("jaspResultsCalledFromJasp", envir = .GlobalEnv, mode = "function", ifnotfound = NA)
 
-  if (!is.na(jaspResultsCalledFromJasp) &&
-      jaspBase::getOS() == "osx" &&
+  if (jaspBase:::getOS() == "osx" &&
       isTRUE(try(jaspResultsCalledFromJasp()))
   ) {
 

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,10 +1,7 @@
 .onLoad <- function(libname, pkgname) {
 
-  # function from zzzWrappers.R inside jaspResults
-  jaspResultsCalledFromJasp <- mget("jaspResultsCalledFromJasp", envir = .GlobalEnv, mode = "function", ifnotfound = NA)
-
   if (jaspBase:::getOS() == "osx" &&
-      isTRUE(try(jaspResultsCalledFromJasp()))
+      isTRUE(try(jaspBase::jaspResultsCalledFromJasp()))
   ) {
 
     jagsHome <- Sys.getenv("JAGS_HOME")


### PR DESCRIPTION
As the jaspResultsCalledFromJasp function is now in jaspBase, we don't have to test whether it exists.