### PR TITLE
Make summary table translatable

### DIFF
--- a/R/jagsModule.R
+++ b/R/jagsModule.R
@@ -314,7 +314,7 @@ JAGSInternal <- function(jaspResults, dataset, options, state = NULL) {
 # Tables ----
 .JAGSoutputTable <- function(jaspResults, options, mcmcResult) {
 
-  tb <- createJaspTable("MCMC Summary")
+  tb <- createJaspTable(title = gettext("MCMC Summary"))
   tb$position <- 1L
   ovt0 <- gettext("Posterior")
   ovt1 <- gettextf("95%% Credible Interval")


### PR DESCRIPTION
This change should make the MCMC Summary table translatable.

Note that I didn't really check if this compiles/works, but I hope it's simple enough to be correct.