### PR TITLE
Replace mainWindow by dataSetInfo

### DIFF
--- a/inst/qml/JAGS.qml
+++ b/inst/qml/JAGS.qml
@@ -185,7 +185,7 @@ Form
 						Group
 						{
 
-							enabled: mainWindow.dataAvailable
+							enabled: dataSetInfo.dataAvailable
 							title: qsTr("Superimpose data")
 
 							DropDown


### PR DESCRIPTION
QML analysis files should not use objects that are not defined outside the QMLComponents library.

Cf jasp-stats/jasp-desktop#5281